### PR TITLE
Use a configurable parent class for saml_controller

### DIFF
--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -1,4 +1,4 @@
-class SamlController < ApplicationController
+class SamlController < OktaSaml.parent_controller.constantize
   include OktaSaml::SessionHelper, OktaApplicationHelper
 
   skip_before_filter :okta_authenticate!, :okta_logout

--- a/lib/okta_saml.rb
+++ b/lib/okta_saml.rb
@@ -5,4 +5,7 @@ module OktaSaml
   if defined?(Rails) && Rails::VERSION::MAJOR >= 3
     require "okta_saml/engine"
   end
+
+  mattr_accessor :parent_controller
+  @@parent_controller = 'ApplicationController'
 end

--- a/spec/requests/saml_spec.rb
+++ b/spec/requests/saml_spec.rb
@@ -36,4 +36,8 @@ describe 'saml controller' do
     end
   end
 
+  it "has a configurable parent class" do
+    # FakeParentController is configured in okta_saml initializer in the dummy app
+    expect(SamlController.ancestors).to include(FakeParentController)
+  end
 end

--- a/test/dummy/config/initializers/okta_saml.rb
+++ b/test/dummy/config/initializers/okta_saml.rb
@@ -1,0 +1,3 @@
+class FakeParentController < ActionController::Base; end
+
+OktaSaml.parent_controller = 'FakeParentController'


### PR DESCRIPTION
We want to subclass a different controller than ApplicationController for our Okta authentication, so we've provided a way to configure the parent controller.
